### PR TITLE
migrate actions/upload-pages-artifact to v3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -140,7 +140,7 @@ runs:
 
     - name: Upload artifact
       if: ${{ inputs.with-odoc == 'true' && inputs.odoc-upload-artifact == 'true' }}
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v3
       with:
         path: ${{ steps.main.outputs.odoc-site-path }}
         name: ${{ inputs.odoc-upload-artifact-name }}


### PR DESCRIPTION
- upload-pages-artifact (v2): https://github.com/actions/upload-pages-artifact/blob/v2/action.yml#L66
- upload-pages-artifact (v3): https://github.com/actions/upload-pages-artifact/blob/v3/action.yml#L77

-----

- [Deprecation notice: v3 of the artifact actions](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)

> Starting January 30th, 2025, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact).

- [MIGRATION.md](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md)

The following two are relevant.

1. `Overwriting an Artifact`
    - set to `true`
3. `Hidden Files`
    - I don't think it is necessary to upload the `odoc` hidden file, so I leave it as default (false).